### PR TITLE
Fix `make distclean` for `./configure --with-config=user`. 

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -10,35 +10,35 @@ modules:
 	@# They may be in the root of SPL_OBJ when building against
 	@# installed devel headers, or they may be in the module
 	@# subdirectory when building against the spl source tree.
-	@if [ -f '@SPL_OBJ@/@SPL_SYMBOLS@' ]; then \
-		/bin/cp '@SPL_OBJ@/@SPL_SYMBOLS@' .; \
-	elif [ -f '@SPL_OBJ@/module/@SPL_SYMBOLS@' ]; then \
-		/bin/cp '@SPL_OBJ@/module/@SPL_SYMBOLS@' .; \
-	else \
-		echo -e "\n" \
-		"*** Missing spl symbols ensure you have built the spl:\n" \
-		"*** - @SPL_OBJ@/@SPL_SYMBOLS@, or\n" \
-		"*** - @SPL_OBJ@/module/@SPL_SYMBOLS@\n"; \
-		exit 1; \
-	fi
-	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
+@CONFIG_KERNEL_TRUE@	@if [ -f '@SPL_OBJ@/@SPL_SYMBOLS@' ]; then \
+@CONFIG_KERNEL_TRUE@ 		/bin/cp '@SPL_OBJ@/@SPL_SYMBOLS@' .; \
+@CONFIG_KERNEL_TRUE@		elif [ -f '@SPL_OBJ@/module/@SPL_SYMBOLS@' ]; then \
+@CONFIG_KERNEL_TRUE@		/bin/cp '@SPL_OBJ@/module/@SPL_SYMBOLS@' .; \
+@CONFIG_KERNEL_TRUE@	else \
+@CONFIG_KERNEL_TRUE@		echo -e "\n" \
+@CONFIG_KERNEL_TRUE@		"*** Missing spl symbols ensure you have built the spl:\n" \
+@CONFIG_KERNEL_TRUE@		"*** - @SPL_OBJ@/@SPL_SYMBOLS@, or\n" \
+@CONFIG_KERNEL_TRUE@		"*** - @SPL_OBJ@/module/@SPL_SYMBOLS@\n"; \
+@CONFIG_KERNEL_TRUE@		exit 1; \
+@CONFIG_KERNEL_TRUE@	fi
+@CONFIG_KERNEL_TRUE@	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
 
 clean:
-	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
-	if [ -f '@SPL_SYMBOLS@' ]; then $(RM) '@SPL_SYMBOLS@'; fi
-	if [ -f '@LINUX_SYMBOLS@' ]; then $(RM) '@LINUX_SYMBOLS@'; fi
-	if [ -f 'Module.markers' ]; then $(RM) 'Module.markers'; fi
+@CONFIG_KERNEL_TRUE@	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
+@CONFIG_KERNEL_TRUE@	if [ -f '@SPL_SYMBOLS@' ]; then $(RM) '@SPL_SYMBOLS@'; fi
+@CONFIG_KERNEL_TRUE@	if [ -f '@LINUX_SYMBOLS@' ]; then $(RM) '@LINUX_SYMBOLS@'; fi
+@CONFIG_KERNEL_TRUE@	if [ -f 'Module.markers' ]; then $(RM) 'Module.markers'; fi
 
 modules_install:
-	@# Install the kernel modules
-	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` \
-		INSTALL_MOD_PATH='$(DESTDIR)' \
-		INSTALL_MOD_DIR='addon/zfs' $@
-	find '$(DESTDIR)/lib/modules/' -name 'modules.*' | xargs $(RM)
-	sysmap='$(DESTDIR)/boot/System.map-@LINUX_VERSION@'; \
-	if [ -f '$$sysmap' ]; then \
-		depmod -ae -F '$$sysmap' '@LINUX_VERSION@'; \
-	fi
+@CONFIG_KERNEL_TRUE@	@# Install the kernel modules
+@CONFIG_KERNEL_TRUE@	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` \
+@CONFIG_KERNEL_TRUE@		INSTALL_MOD_PATH='$(DESTDIR)' \
+@CONFIG_KERNEL_TRUE@		INSTALL_MOD_DIR='addon/zfs' $@
+@CONFIG_KERNEL_TRUE@	find '$(DESTDIR)/lib/modules/' -name 'modules.*' | xargs $(RM)
+@CONFIG_KERNEL_TRUE@	sysmap='$(DESTDIR)/boot/System.map-@LINUX_VERSION@'; \
+@CONFIG_KERNEL_TRUE@	if [ -f '$$sysmap' ]; then \
+@CONFIG_KERNEL_TRUE@		depmod -ae -F '$$sysmap' '@LINUX_VERSION@'; \
+@CONFIG_KERNEL_TRUE@	fi
 
 modules_uninstall:
 	@# Uninstall the kernel modules
@@ -47,6 +47,8 @@ modules_uninstall:
 distdir:
 
 distclean maintainer-clean: clean
+@CONFIG_KERNEL_FALSE@	-rm -f Makefile */Makefile
+
 install: modules_install
 uninstall: modules_uninstall
 all: modules

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -10,10 +10,10 @@ modules:
 	@# They may be in the root of SPL_OBJ when building against
 	@# installed devel headers, or they may be in the module
 	@# subdirectory when building against the spl source tree.
-	@if [ -f @SPL_OBJ@/@SPL_SYMBOLS@ ]; then \
-		/bin/cp @SPL_OBJ@/@SPL_SYMBOLS@ .; \
-	elif [ -f @SPL_OBJ@/module/@SPL_SYMBOLS@ ]; then \
-		/bin/cp @SPL_OBJ@/module/@SPL_SYMBOLS@ .; \
+	@if [ -f '@SPL_OBJ@/@SPL_SYMBOLS@' ]; then \
+		/bin/cp '@SPL_OBJ@/@SPL_SYMBOLS@' .; \
+	elif [ -f '@SPL_OBJ@/module/@SPL_SYMBOLS@' ]; then \
+		/bin/cp '@SPL_OBJ@/module/@SPL_SYMBOLS@' .; \
 	else \
 		echo -e "\n" \
 		"*** Missing spl symbols ensure you have built the spl:\n" \
@@ -21,28 +21,28 @@ modules:
 		"*** - @SPL_OBJ@/module/@SPL_SYMBOLS@\n"; \
 		exit 1; \
 	fi
-	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
+	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
 
 clean:
-	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
-	if [ -f @SPL_SYMBOLS@ ]; then $(RM) @SPL_SYMBOLS@; fi
-	if [ -f @LINUX_SYMBOLS@ ]; then $(RM) @LINUX_SYMBOLS@; fi
-	if [ -f Module.markers ]; then $(RM) Module.markers; fi
+	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` @KERNELMAKE_PARAMS@ $@
+	if [ -f '@SPL_SYMBOLS@' ]; then $(RM) '@SPL_SYMBOLS@'; fi
+	if [ -f '@LINUX_SYMBOLS@' ]; then $(RM) '@LINUX_SYMBOLS@'; fi
+	if [ -f 'Module.markers' ]; then $(RM) 'Module.markers'; fi
 
 modules_install:
 	@# Install the kernel modules
-	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` \
-		INSTALL_MOD_PATH=$(DESTDIR) \
-		INSTALL_MOD_DIR=addon/zfs $@
-	find $(DESTDIR)/lib/modules/ -name 'modules.*' | xargs $(RM)
-	sysmap=$(DESTDIR)/boot/System.map-@LINUX_VERSION@; \
-	if [ -f $$sysmap ]; then \
-		depmod -ae -F $$sysmap @LINUX_VERSION@; \
+	$(MAKE) -C '@LINUX_OBJ@' SUBDIRS=`pwd` \
+		INSTALL_MOD_PATH='$(DESTDIR)' \
+		INSTALL_MOD_DIR='addon/zfs' $@
+	find '$(DESTDIR)/lib/modules/' -name 'modules.*' | xargs $(RM)
+	sysmap='$(DESTDIR)/boot/System.map-@LINUX_VERSION@'; \
+	if [ -f '$$sysmap' ]; then \
+		depmod -ae -F '$$sysmap' '@LINUX_VERSION@'; \
 	fi
 
 modules_uninstall:
 	@# Uninstall the kernel modules
-	$(RM) -R $(DESTDIR)/lib/modules/@LINUX_VERSION@/addon/zfs
+	$(RM) -R '$(DESTDIR)/lib/modules/@LINUX_VERSION@/addon/zfs'
 
 distdir:
 

--- a/module/avl/Makefile.in
+++ b/module/avl/Makefile.in
@@ -1,9 +1,9 @@
 MODULE := zavl
 
 EXTRA_CFLAGS  = @KERNELCPPFLAGS@
-EXTRA_CFLAGS += -include @SPL_OBJ@/spl_config.h
-EXTRA_CFLAGS += -include @abs_top_builddir@/zfs_config.h
-EXTRA_CFLAGS += -I@abs_top_srcdir@/include -I@SPL@/include -I@SPL@
+EXTRA_CFLAGS += -include '@SPL_OBJ@/spl_config.h'
+EXTRA_CFLAGS += -include '@abs_top_builddir@/zfs_config.h'
+EXTRA_CFLAGS += -I'@abs_top_srcdir@/include' -I'@SPL@/include' -I'@SPL@'
 
 obj-m := $(MODULE).o
 

--- a/module/nvpair/Makefile.in
+++ b/module/nvpair/Makefile.in
@@ -1,9 +1,9 @@
 MODULE := znvpair
 
 EXTRA_CFLAGS  = @KERNELCPPFLAGS@
-EXTRA_CFLAGS += -include @SPL_OBJ@/spl_config.h
-EXTRA_CFLAGS += -include @abs_top_builddir@/zfs_config.h
-EXTRA_CFLAGS += -I@abs_top_srcdir@/include -I@SPL@/include -I@SPL@
+EXTRA_CFLAGS += -include '@SPL_OBJ@/spl_config.h'
+EXTRA_CFLAGS += -include '@abs_top_builddir@/zfs_config.h'
+EXTRA_CFLAGS += -I'@abs_top_srcdir@/include' -I'@SPL@/include' -I'@SPL@'
 
 obj-m := $(MODULE).o
 

--- a/module/unicode/Makefile.in
+++ b/module/unicode/Makefile.in
@@ -1,9 +1,9 @@
 MODULE := zunicode
 
 EXTRA_CFLAGS  = @KERNELCPPFLAGS@
-EXTRA_CFLAGS += -include @SPL_OBJ@/spl_config.h
-EXTRA_CFLAGS += -include @abs_top_builddir@/zfs_config.h
-EXTRA_CFLAGS += -I@abs_top_srcdir@/include -I@SPL@/include -I@SPL@
+EXTRA_CFLAGS += -include '@SPL_OBJ@/spl_config.h'
+EXTRA_CFLAGS += -include '@abs_top_builddir@/zfs_config.h'
+EXTRA_CFLAGS += -I'@abs_top_srcdir@/include' -I'@SPL@/include' -I'@SPL@'
 
 obj-m := $(MODULE).o
 

--- a/module/zcommon/Makefile.in
+++ b/module/zcommon/Makefile.in
@@ -1,9 +1,9 @@
 MODULE := zcommon
 
 EXTRA_CFLAGS  = @KERNELCPPFLAGS@
-EXTRA_CFLAGS += -include @SPL_OBJ@/spl_config.h
-EXTRA_CFLAGS += -include @abs_top_builddir@/zfs_config.h
-EXTRA_CFLAGS += -I@abs_top_srcdir@/include -I@SPL@/include -I@SPL@
+EXTRA_CFLAGS += -include '@SPL_OBJ@/spl_config.h'
+EXTRA_CFLAGS += -include '@abs_top_builddir@/zfs_config.h'
+EXTRA_CFLAGS += -I'@abs_top_srcdir@/include' -I'@SPL@/include' -I'@SPL@'
 
 obj-m := $(MODULE).o
 

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -1,9 +1,9 @@
 MODULE := zfs
 
 EXTRA_CFLAGS += @KERNELCPPFLAGS@
-EXTRA_CFLAGS += -include @SPL_OBJ@/spl_config.h
-EXTRA_CFLAGS += -include @abs_top_builddir@/zfs_config.h
-EXTRA_CFLAGS += -I@abs_top_srcdir@/include -I@SPL@/include -I@SPL@
+EXTRA_CFLAGS += -include '@SPL_OBJ@/spl_config.h'
+EXTRA_CFLAGS += -include '@abs_top_builddir@/zfs_config.h'
+EXTRA_CFLAGS += -I'@abs_top_srcdir@/include' -I'@SPL@/include' -I'@SPL@'
 
 obj-m := $(MODULE).o
 

--- a/module/zpios/Makefile.in
+++ b/module/zpios/Makefile.in
@@ -1,9 +1,9 @@
 MODULE := zpios
 
 EXTRA_CFLAGS  = @KERNELCPPFLAGS@
-EXTRA_CFLAGS += -include @SPL_OBJ@/spl_config.h
-EXTRA_CFLAGS += -include @abs_top_builddir@/zfs_config.h
-EXTRA_CFLAGS += -I@abs_top_srcdir@/include -I@SPL@/include -I@SPL@
+EXTRA_CFLAGS += -include '@SPL_OBJ@/spl_config.h'
+EXTRA_CFLAGS += -include '@abs_top_builddir@/zfs_config.h'
+EXTRA_CFLAGS += -I'@abs_top_srcdir@/include' -I'@SPL@/include' -I'@SPL@'
 
 obj-m := $(MODULE).o
 


### PR DESCRIPTION
Running `make distclean` after `./configure --with-config=user` fails with this error message:

```
Making distclean in module
make[1]: Entering directory `/zfs/module'
make -C  SUBDIRS=`pwd`  clean
make: Entering an unknown directory
make: *** SUBDIRS=/zfs/module: No such file or directory.  Stop.
make: Leaving an unknown directory
make[1]: *** [clean] Error 2
make[1]: Leaving directory `/zfs/module'
make: *** [distclean-recursive] Error 1
```

This happens because module/ has an external dependency on the Linux build system, which is unconfigured if CONFIG_KERNEL is not set.

This change is worthwhile because debhelper assumes that all configurations produce a working distclean rule.
