### PR TITLE
Add zfs-initramfs Depends: initramfs-tools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -147,7 +147,7 @@ Description: Native ZFS filesystem kernel modules for Linux
 Package: zfs-initramfs
 Section: kernel
 Architecture: linux-any
-Depends: ${misc:Depends}, zfsutils, zfs-grub
+Depends: ${misc:Depends}, initramfs-tools, zfsutils, zfs-grub
 Description: Native ZFS root filesystem capabilities for Linux
  This package adds ZFS to the system initramfs with a hook
  for the initramfs-tools infrastructure.


### PR DESCRIPTION
[Debian Policy 7.2](http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps) / [Ubuntu Policy 7.2](http://people.canonical.com/~cjwatson/ubuntu-policy/policy.html/ch-relationships.html#s-binarydeps):

> The Depends field should be used if the depended-on package is required for the depending package to provide a significant amount of functionality.

zfs-initramfs loses all functionality if initramfs-tools is not installed. And since it's not useful in any way without initramfs-tools, adding this dependency doesn't hurt anyone.
