### PR TITLE
Add zfsutils Depends: mawk | awk

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -155,7 +155,7 @@ Description: Native ZFS root filesystem capabilities for Linux
 Package: zfsutils
 Section: admin
 Architecture: linux-any
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, mawk | awk
 Recommends: zfs-dkms
 Suggests: nfs-kernel-server, zfs-initramfs
 Conflicts: zfs, zfs-fuse


### PR DESCRIPTION
If awk is not installed, zfsutils causes "zfs<TAB>" in bash to throw errors (if bash-completion is installed, which is the default on Ubuntu).
