### PR TITLE
zfsutils Depends initscripts, lsb-base

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -155,7 +155,7 @@ Description: Native ZFS root filesystem capabilities for Linux
 Package: zfsutils
 Section: admin
 Architecture: linux-any
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, initscripts, lsb-base
 Recommends: zfs-dkms
 Suggests: nfs-kernel-server, zfs-initramfs
 Conflicts: zfs, zfs-fuse


### PR DESCRIPTION
/etc/init.d/zfs-{mount,share} source /lib/lsb/init-functions, which is
provided by lsb-base.

/etc/init.d/zfs-{mount,share} source /lib/init/vars.sh, which is
provided by initscripts.

There's no downside to these dependencies, as the ZFS PPA is not
supported on systems that don't have the init stack installed.
