### PR TITLE
Added call to hide Plymouth when error shell is launched.

### DIFF
--- a/debian/tree/zfs-initramfs/usr/share/initramfs-tools/scripts/zfs
+++ b/debian/tree/zfs-initramfs/usr/share/initramfs-tools/scripts/zfs
@@ -77,6 +77,7 @@ mountroot()
 
 	if [ "$ZFS_ERROR" -ne 0 ]
 	then
+	    [ -x /bin/plymouth ] && /bin/plymouth hide-splash
 		echo "Command: zpool import -f -N $ZFS_RPOOL"
 		echo "Message: $ZFS_STDERR"
 		echo "Error: $ZFS_ERROR"
@@ -96,6 +97,7 @@ mountroot()
 
 	if [ -z "$ZFS_BOOTFS" ]
 	then
+		[ -x /bin/plymouth ] && /bin/plymouth hide-splash
 		echo "Command: zpool list -H -o bootfs $ZFS_RPOOL"
 		echo "Error: $ZFS_ERROR, unable to get the bootfs property."
 		echo ""


### PR DESCRIPTION
During boot up, if a user is running Plymouth then it's impossible to see the spawned shell that allows them to recover from ZFS mounting errors (or even be notified of them). This simple patch adds a call to `plymouth hide-splash` before the recovery shell is launched, which allows the user to be alerted to the error and correct it if possible.
