### PR TITLE
Missed adding 1 call to Plymouth hide-splash in the last patch.

### DIFF
--- a/debian/tree/zfs-initramfs/usr/share/initramfs-tools/scripts/zfs
+++ b/debian/tree/zfs-initramfs/usr/share/initramfs-tools/scripts/zfs
@@ -127,6 +127,7 @@ mountroot()
 
 	if [ "$ZFS_ERROR" -ne 0 ]
 	then
+		[ -x /bin/plymouth ] && /bin/plymouth hide-splash
 		echo ""
 		echo "Command: mount -t zfs -o zfsutil $ZFS_BOOTFS $rootmnt"
 		echo "Message: $ZFS_STDERR"


### PR DESCRIPTION
This is an extra which I missed in the last patch - it adds a call to plymouth hide-splash in the 3rd place in the zfs script which can invoke a busybox shell (that I overlooked with the last one).
