### PR TITLE
Updated bash completions and sudoers

### DIFF
--- a/debian/tree/zfsutils/etc/bash_completion.d/zfs
+++ b/debian/tree/zfsutils/etc/bash_completion.d/zfs
@@ -82,7 +82,7 @@ __zfs_argument_chosen()
     for word in $(seq $((COMP_CWORD-1)) -1 2)
     do
         local prev="${COMP_WORDS[$word]}"
-        if [[ "$prev" == [^,]*,* ]]
+        if [[ "$prev" == [^,]*,* ]] || [[ "$prev" == *:* ]]
         then
             return 0
         fi
@@ -131,8 +131,8 @@ __zfs_complete()
 {
     local cur prev cmd cmds
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    # Don't split on colon
+    _get_comp_words_by_ref -n : -c cur -p prev -w COMP_WORDS -i COMP_CWORD
     cmd="${COMP_WORDS[1]}"
     cmds=$(__zfs_get_commands)
 
@@ -145,7 +145,6 @@ __zfs_complete()
     case "${cmd}" in
         clone)
             __zfs_complete_ordered_arguments "$(__zfs_list_snapshots)" "$(__zfs_list_filesystems) $(__zfs_list_volumes)" $cur
-            return 0
             ;;
         get)
             case "${prev}" in
@@ -175,11 +174,9 @@ __zfs_complete()
                     fi
                     ;;
             esac
-            return 0
             ;;
         inherit)
             __zfs_complete_ordered_arguments "$(__zfs_get_inheritable_properties)" "$(__zfs_list_datasets)" $cur
-            return 0
             ;;
         list)
             case "${prev}" in
@@ -207,30 +204,25 @@ __zfs_complete()
                     fi
                     ;;
             esac
-            return 0
             ;;
         promote)
             COMPREPLY=($(compgen -W "$(__zfs_list_filesystems)" -- "$cur"))
-            return 0
             ;;
         rollback|send)
             COMPREPLY=($(compgen -W "$(__zfs_list_snapshots)" -- "$cur"))
-            return 0
             ;;
         snapshot)
             COMPREPLY=($(compgen -W "$(__zfs_list_filesystems) $(__zfs_list_volumes)" -- "$cur"))
-            return 0
             ;;
         set)
             __zfs_complete_ordered_arguments "$(__zfs_get_editable_properties)" "$(__zfs_list_filesystems) $(__zfs_list_volumes)" $cur
-            return 0
             ;;
         *)
             COMPREPLY=($(compgen -W "$(__zfs_list_datasets)" -- "$cur"))
-            return 0
             ;;
     esac
-
+    __ltrim_colon_completions "$cur"
+    return 0
 }
 
 __zpool_get_commands()

--- a/debian/tree/zfsutils/etc/bash_completion.d/zfs
+++ b/debian/tree/zfsutils/etc/bash_completion.d/zfs
@@ -1,4 +1,4 @@
-# Copyright (c) 2010, Aneurin Price <aneurin.price@gmail.com>
+# Copyright (c) 2013, Aneurin Price <aneurin.price@gmail.com>
 
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -21,48 +21,64 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+if [ -w /dev/zfs ]; then
+    __ZFS_CMD="zfs"
+    __ZPOOL_CMD="zpool"
+else
+    __ZFS_CMD="sudo zfs"
+    __ZPOOL_CMD="sudo zpool"
+fi
+
+ZFS_COMPLETE_DATASETS_INCLUDE_SNAPSHOTS=false
+
 __zfs_get_commands()
 {
-    zfs 2>&1 | awk '/^\t[a-z]/ {print $1}' | uniq
+    $__ZFS_CMD 2>&1 | awk '/^\t[a-z]/ {print $1}' | uniq
 }
 
 __zfs_get_properties()
 {
-    zfs get 2>&1 | awk '$2 == "YES" || $2 == "NO" {print $1}'; echo all
+    $__ZFS_CMD get 2>&1 | awk '$2 == "YES" || $2 == "NO" {print $1}'; echo all
 }
 
 __zfs_get_editable_properties()
 {
-    zfs get 2>&1 | awk '$2 == "YES" {printf("%s=\n", $1)}'
+    $__ZFS_CMD get 2>&1 | awk '$2 == "YES" {printf("%s=\n", $1)}'
 }
 
 __zfs_get_inheritable_properties()
 {
-    zfs get 2>&1 | awk '$3 == "YES" {print $1}'
+    $__ZFS_CMD get 2>&1 | awk '$3 == "YES" {print $1}'
 }
 
 __zfs_list_datasets()
 {
-    zfs list -H -o name
+    if $ZFS_COMPLETE_DATASETS_INCLUDE_SNAPSHOTS
+    then
+        $__ZFS_CMD list -H -o name -t all
+    else
+        $__ZFS_CMD list -H -o name
+    fi
 }
 
 __zfs_list_filesystems()
 {
-    zfs list -H -o name -t filesystem
+    $__ZFS_CMD list -H -o name -t filesystem
 }
 
 __zfs_list_snapshots()
 {
-    zfs list -H -o name -t snapshot
+    $__ZFS_CMD list -H -o name -t snapshot
 }
 
 __zfs_list_volumes()
 {
-    zfs list -H -o name -t volume
+    $__ZFS_CMD list -H -o name -t volume
 }
 
 __zfs_argument_chosen()
 {
+    local word property
     for word in $(seq $((COMP_CWORD-1)) -1 2)
     do
         local prev="${COMP_WORDS[$word]}"
@@ -159,22 +175,22 @@ __zfs_complete()
 
 __zpool_get_commands()
 {
-    zpool 2>&1 | awk '/^\t[a-z]/ {print $1}' | uniq
+    $__ZPOOL_CMD 2>&1 | awk '/^\t[a-z]/ {print $1}' | uniq
 }
 
 __zpool_get_properties()
 {
-    zpool get 2>&1 | awk '$2 == "YES" || $2 == "NO" {print $1}'; echo all
+    $__ZPOOL_CMD get 2>&1 | awk '$2 == "YES" || $2 == "NO" {print $1}'; echo all
 }
 
 __zpool_get_editable_properties()
 {
-    zpool get 2>&1 | awk '$2 == "YES" {printf("%s=\n", $1)}'
+    $__ZPOOL_CMD get 2>&1 | awk '$2 == "YES" {printf("%s=\n", $1)}'
 }
 
 __zpool_list_pools()
 {
-    zpool list -H -o name
+    $__ZPOOL_CMD list -H -o name
 }
 
 __zpool_complete()

--- a/debian/tree/zfsutils/etc/bash_completion.d/zfs
+++ b/debian/tree/zfsutils/etc/bash_completion.d/zfs
@@ -70,6 +70,15 @@ __zfs_match_snapshot()
     fi
 }
 
+__zfs_match_explicit_snapshot()
+{
+    local base_dataset=$(expr "$cur" : '\(.*\)@')
+    if [ ! "x$base_dataset" = "x" ]
+    then
+        $__ZFS_CMD list -H -o name -t snapshot -d 1 $base_dataset
+    fi
+}
+
 __zfs_list_volumes()
 {
     $__ZFS_CMD list -H -o name -t volume
@@ -183,7 +192,7 @@ __zfs_complete()
                     else
                         if __zfs_argument_chosen $(__zfs_get_properties)
                         then
-                            COMPREPLY=($(compgen -W "$(__zfs_list_datasets)" -- "$cur"))
+                            COMPREPLY=($(compgen -W "$(__zfs_match_explicit_snapshot) $(__zfs_list_datasets)" -- "$cur"))
                         else
                             __zfs_complete_multiple_options "$(__zfs_get_properties)" "$cur"
                         fi
@@ -192,7 +201,7 @@ __zfs_complete()
             esac
             ;;
         inherit)
-            __zfs_complete_ordered_arguments "$(__zfs_get_inheritable_properties)" "$(__zfs_list_datasets)" $cur
+            __zfs_complete_ordered_arguments "$(__zfs_get_inheritable_properties)" "$(__zfs_match_explicit_snapshot) $(__zfs_list_datasets)" $cur
             ;;
         list)
             case "${prev}" in
@@ -216,7 +225,7 @@ __zfs_complete()
                     then
                         COMPREPLY=($(compgen -W "-{H,r,d,o,t,s,S}" -- "$cur"))
                     else
-                        COMPREPLY=($(compgen -W "$(__zfs_list_datasets)" -- "$cur"))
+                        COMPREPLY=($(compgen -W "$(__zfs_match_explicit_snapshot) $(__zfs_list_datasets)" -- "$cur"))
                     fi
                     ;;
             esac
@@ -247,7 +256,7 @@ __zfs_complete()
             __zfs_complete_ordered_arguments "$(__zfs_get_editable_properties)" "$(__zfs_list_filesystems) $(__zfs_list_volumes)" $cur
             ;;
         *)
-            COMPREPLY=($(compgen -W "$(__zfs_list_datasets)" -- "$cur"))
+            COMPREPLY=($(compgen -W "$(__zfs_match_explicit_snapshot) $(__zfs_list_datasets)" -- "$cur"))
             ;;
     esac
     __ltrim_colon_completions "$cur"

--- a/debian/tree/zfsutils/etc/bash_completion.d/zfs
+++ b/debian/tree/zfsutils/etc/bash_completion.d/zfs
@@ -21,7 +21,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-if [ -w /dev/zfs ]; then
+if [[ -w /dev/zfs ]]; then
     __ZFS_CMD="zfs"
     __ZPOOL_CMD="zpool"
 else
@@ -61,8 +61,8 @@ __zfs_list_filesystems()
 
 __zfs_match_snapshot()
 {
-    local base_dataset=$(expr "$cur" : '\(.*\)@')
-    if [ ! "x$base_dataset" = "x" ]
+    local base_dataset=${cur%@*}
+    if [[ $base_dataset != $cur ]]
     then
         $__ZFS_CMD list -H -o name -t snapshot -d 1 $base_dataset
     else
@@ -72,8 +72,8 @@ __zfs_match_snapshot()
 
 __zfs_match_explicit_snapshot()
 {
-    local base_dataset=$(expr "$cur" : '\(.*\)@')
-    if [ ! "x$base_dataset" = "x" ]
+    local base_dataset=${cur%@*}
+    if [[ $base_dataset != $cur ]]
     then
         $__ZFS_CMD list -H -o name -t snapshot -d 1 $base_dataset
     fi
@@ -98,7 +98,7 @@ __zfs_argument_chosen()
             fi
             for property in $@
             do
-                if [ "x$prev" = "x$property" ]
+                if [[ $prev == "$property" ]]
                 then
                     return 0
                 fi
@@ -129,7 +129,7 @@ __zfs_complete_multiple_options()
 
     COMPREPLY=($(compgen -W "$options" -- "${cur##*,}"))
     local existing_opts=$(expr "$cur" : '\(.*,\)')
-    if [ ! "x$existing_opts" = "x" ]
+    if [[ $existing_opts ]] 
     then
         COMPREPLY=( "${COMPREPLY[@]/#/${existing_opts}}" )
     fi
@@ -138,7 +138,7 @@ __zfs_complete_multiple_options()
 __zfs_complete_switch()
 {
     local options=$1
-    if [ "x${cur:0:1}" = "x-" ]
+    if [[ ${cur:0:1} == - ]]
     then
         COMPREPLY=($(compgen -W "-{$options}" -- "$cur"))
         return 0
@@ -155,7 +155,7 @@ __zfs_complete()
     _get_comp_words_by_ref -n : -c cur -p prev -w COMP_WORDS -i COMP_CWORD
     cmd="${COMP_WORDS[1]}"
 
-    if [ "${prev##*/}" = "zfs" ]
+    if [[ ${prev##*/} == zfs ]]
     then
         cmds=$(__zfs_get_commands)
         COMPREPLY=($(compgen -W "$cmds -?" -- "$cur"))
@@ -293,7 +293,7 @@ __zpool_complete()
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     cmd="${COMP_WORDS[1]}"
 
-    if [ "${prev##*/}" = "zpool" ]
+    if [[ ${prev##*/} == zpool ]]
     then
         cmds=$(__zpool_get_commands)
         COMPREPLY=($(compgen -W "$cmds" -- "$cur"))
@@ -306,7 +306,7 @@ __zpool_complete()
             return 0
             ;;
         import)
-            if [ "x$prev" = "x-d" ]
+            if [[ $prev == -d ]]
             then
                 _filedir -d
             else


### PR DESCRIPTION
I recently realised that my bash completions are being shipped as part of the Debian packages for ZoL, which prompted me to make some updates.

These completions still aren't complete, but they now include full-featured completions for more of the commands (basically any which I use with any regularity in my day job). Existing completions are greatly improved over the original, significantly more useful if you have a lot of snapshots, and somewhat better in the case where you don't have access to /dev/zfs, but _do_ have passwordless sudo set up for read-only commands, as suggested by ZoL.

I'm not sure if you actually use this repo as a working area at all, plus I recognise that having a number of commits for such a small feature might be an inappropriate level of detail, so feel free to ignore the pull request and just grab the file if you prefer.
