### PR TITLE
Re-enable zfs-dracut packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -138,18 +138,18 @@ Description: Native ZFS filesystem kernel modules for Linux
  .
  Includes the SPA, DMU, ZVOL, and ZPL components of ZFS.
 
-#Package: zfs-dracut
-#Section: kernel
-#Architecture: linux-any
-#Depends: ${misc:Depends}, dracut, zfsutils
-#Description: Native ZFS root filesystem capabilities for Linux
-# This package adds ZFS to the system initramfs with a hook
-# for the dracut infrastructure.
+Package: zfs-dracut
+Section: kernel
+Architecture: linux-any
+Depends: ${misc:Depends}, dracut, zfsutils
+Description: Native ZFS root filesystem capabilities for Linux
+ This package adds ZFS to the system initramfs with a hook
+ for the dracut infrastructure.
 
 Package: zfs-initramfs
 Section: kernel
 Architecture: linux-any
-Depends: ${misc:Depends}, zfsutils
+Depends: ${misc:Depends}, initramfs-tools, zfsutils
 Description: Native ZFS root filesystem capabilities for Linux
  This package adds ZFS to the system initramfs with a hook
  for the initramfs-tools infrastructure.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,4 +1,3 @@
 0002-Prevent-manual-builds-in-the-DKMS-source.patch
 0003-Remove-all-upstream-init.d-components.patch
-0004-Remove-the-upstream-dracut-component.patch
 0005-Remove-userland-dist-rules.patch

--- a/debian/zfs-dracut.install
+++ b/debian/zfs-dracut.install
@@ -1,1 +1,1 @@
-usr/share/dracut
+usr/lib/dracut

--- a/dracut/90zfs/mount-zfs.sh.in
+++ b/dracut/90zfs/mount-zfs.sh.in
@@ -18,13 +18,13 @@ case "$root" in
 
 			# Might be imported by the kernel module, so try searching before
 			# we import anything.
-			zfsbootfs=`zpool list -H -o bootfs | sed -n '/-/ !p' | sed 'q'`
+			zfsbootfs=`zpool list -H -o bootfs | sed -n '/^-$/ !p' | sed 'q'`
 			if [ "$?" != "0" ] || [ "$zfsbootfs" = "" ] || \
 				[ "$zfsbootfs" = "no pools available" ] ; then
 				# Not there, so we need to import everything.
 				info "ZFS: Attempting to import additional pools."
 				zpool import -N -a ${ZPOOL_FORCE}
-				zfsbootfs=`zpool list -H -o bootfs | sed -n '/-/ !p' | sed 'q'`
+				zfsbootfs=`zpool list -H -o bootfs | sed -n '/^-$/ !p' | sed 'q'`
 				if [ "$?" != "0" ] || [ "$zfsbootfs" = "" ] || \
 					[ "$zfsbootfs" = "no pools available" ] ; then
 					rootok=0


### PR DESCRIPTION
This was disabled with f044301bacbe69848fd4c0fcd02f5b4d08d7f298 in January 2012 as it was broken back then, but the situation has improved vastly in the meantime. The zfs-dracut package not only works well with dracut-038 on Debian Jessie but offers one significant advantage over initramfs-tools: The ability to export a ZFS root on shutdown, eliminating the necessity to force-import on every reboot. A patch to achieve that was submitted yesterday with zfsonlinux/zfs#2766. (I can add that patch to this pull request if you want.) Note that there's currently a bug in Debian's dracut_038-2 package which prevents the systemd unit files from being included in the package. I'll submit a bug report to the maintainer in a bit and will add the bug number in a comment here. Without that fix, exporting the ZFS root on shutdown doesn't work.

I've also added a dependency to package zfs-initramfs on initramfs-tools, analogously to the dependency of package zfs-dracut on dracut. This ensures that a user may install only one of zfs-dracut and zfs-initramfs at the same time since dracut and initramfs-tools conflict.

I'm not sure if this is the correct branch to submit this pull request, all others seemed stale. Please let me know if I should re-submit to a different branch. Thanks.
