### PR TITLE
zfs-initramfs: Support GRUB's native root=ZFS=

### DIFF
--- a/debian/tree/zfs-initramfs/usr/share/initramfs-tools/conf.d/zfs
+++ b/debian/tree/zfs-initramfs/usr/share/initramfs-tools/conf.d/zfs
@@ -1,0 +1,8 @@
+for x in $(cat /proc/cmdline)
+do
+	case $x in
+		root=ZFS=*)
+			BOOT=zfs
+			;;
+	esac
+done

--- a/debian/tree/zfs-initramfs/usr/share/initramfs-tools/scripts/zfs
+++ b/debian/tree/zfs-initramfs/usr/share/initramfs-tools/scripts/zfs
@@ -75,6 +75,12 @@ mountroot()
 		ZFS_RPOOL=$(echo "$ZFS_RPOOL" | sed -e 's,/.*,,')
 	fi
 
+	if [ -z "$ZFS_RPOOL" ]
+	then
+		ZFS_BOOTFS=${ROOT#ZFS=}
+		ZFS_RPOOL=$(echo "$ZFS_BOOTFS" | sed -e 's,/.*,,')
+	fi
+
 	# Use "rpool" as the default, like on most Solaris systems.
 	[ -z "$ZFS_RPOOL" ] && ZFS_RPOOL='rpool'
 


### PR DESCRIPTION
Upstream GRUB sets root=ZFS=rpool/path/to/rootfs by default.  By
supporting that syntax (while retaining the existing support for
backwards compatibility), we can work out-of-the-box.
